### PR TITLE
Update Maven Compiler and Surefire plugins

### DIFF
--- a/plugin-versions.properties
+++ b/plugin-versions.properties
@@ -3,8 +3,8 @@ site      3.7
 install   2.5.2
 deploy    2.8.2
 resources 3.0.2
-compiler  3.7.0
-surefire  2.20.1
+compiler  3.8.0
+surefire  2.22.1
 jar       3.0.2
 ejb       3.0.0
 plugin    3.5.1


### PR DESCRIPTION
Update the plugins for out-of-the-box Java 11 and
JUnit 5 support in the generated projects.