### PR TITLE
Add \ to print.css ${basedir} to correct generate path

### DIFF
--- a/maven-archetype-site-skin/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/maven-archetype-site-skin/src/main/resources-filtered/archetype-resources/pom.xml
@@ -124,7 +124,7 @@
 
           <!-- include the print.css -->
           <resource>
-            <directory>${basedir}/src/main/resources</directory>
+            <directory>\${basedir}/src/main/resources</directory>
             <includes>
               <include>css/print.css</include>
             </includes>


### PR DESCRIPTION
When you generate a site skin with maven-archetype-site-skin, you have a bug in the print.css basedir path. It generate a full absolute path with \home\herve..