### PR TITLE
Enabled generating Java 9+ projects as well as using JUnit 5.x

### DIFF
--- a/maven-archetype-quickstart/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/maven-archetype-quickstart/src/main/resources-filtered/archetype-resources/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 #macro( compilerProperties $ver )
 #if ($ver == "9" || $ver == "10" || $ver == "11" || $ver == "12" || $ver == "13" || $ver == "14")
     <maven.compiler.release>${ver}</maven.compiler.release>
@@ -8,7 +7,6 @@
     <maven.compiler.target>${ver}</maven.compiler.target>
 #end
 #end
-
 #macro( junit $ver )
 #if ( $ver.startsWith("4.") )
     <dependency>
@@ -32,7 +30,6 @@
     </dependency>
 #end
 #end
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/maven-archetype-quickstart/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/maven-archetype-quickstart/src/main/resources-filtered/archetype-resources/pom.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 #macro( compilerProperties $ver )
-  #if ($ver == "9" || $ver == "10" || $ver == "11" || $ver == "12" || $ver == "13" || $ver == "14")
+#if ($ver == "9" || $ver == "10" || $ver == "11" || $ver == "12" || $ver == "13" || $ver == "14")
     <maven.compiler.release>${ver}</maven.compiler.release>
-  #else
+#else
     <maven.compiler.source>${ver}</maven.compiler.source>
     <maven.compiler.target>${ver}</maven.compiler.target>
-  #end
+#end
 #end
 
 #macro( junit $ver )
-  #if ( $ver.startsWith("4.") )
+#if ( $ver.startsWith("4.") )
     <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${ver}</version>
+      <scope>test</scope>
     </dependency>
-  #elseif ( $ver.startsWith("5.") )
+#elseif ( $ver.startsWith("5.") )
     <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${ver}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${ver}</version>
+      <scope>test</scope>
     </dependency>
-  #end
+#end
 #end
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -47,19 +47,19 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    #if ( ${javaCompilerVersion} == $null )
-      #compilerProperties( "1.7" )
-    #else
-      #compilerProperties( ${javaCompilerVersion} )
-    #end
+#if ( ${javaCompilerVersion} == $null )
+#compilerProperties( "1.7" )
+#else
+#compilerProperties( ${javaCompilerVersion} )
+#end
   </properties>
 
   <dependencies>
-    #if ( ${junitVersion} == $null )
-      #junit( "4.11" )
-    #else
-      #junit( ${junitVersion} )
-    #end
+#if ( ${junitVersion} == $null )
+#junit( "4.12" )
+#else
+#junit( ${junitVersion} )
+#end
   </dependencies>
 
   <build>

--- a/maven-archetype-quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven-archetype-quickstart/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -18,9 +18,10 @@ KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
-<archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
-  name="quickstart" partial="false">
+<archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0" 
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
+                      name="quickstart" partial="false">
 
   <fileSets>
     <fileSet filtered="true" packaged="true">

--- a/maven-archetype-quickstart/src/main/resources/archetype-resources/src/test/java/AppTest.java
+++ b/maven-archetype-quickstart/src/main/resources/archetype-resources/src/test/java/AppTest.java
@@ -1,5 +1,6 @@
 package $package;
 
+#if ( $junitVersion == $null || $junitVersion.startsWith("4."))
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -7,14 +8,33 @@ import org.junit.Test;
 /**
  * Unit test for simple App.
  */
-public class AppTest 
-{
+public class AppTest {
+
     /**
      * Rigorous Test :-)
      */
     @Test
-    public void shouldAnswerWithTrue()
-    {
-        assertTrue( true );
+    public void shouldAnswerWithTrue() {
+        assertTrue(true);
     }
 }
+#else
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest {
+
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue() {
+        assertTrue(true);
+    }
+}
+#end
+

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/archetype.properties
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/archetype.properties
@@ -1,0 +1,6 @@
+groupId=archetype.it
+artifactId=java-11-junit-542-quickstart
+version=0.1-SNAPSHOT
+package=it.pkg
+javaCompilerVersion=11
+junitVersion=5.4.2

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/goal.txt
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/goal.txt
@@ -1,0 +1,1 @@
+validate

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/pom.xml
@@ -16,23 +16,23 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-                <maven.compiler.release>11</maven.compiler.release>
-        </properties>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
 
   <dependencies>
-                <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>5.4.2</version>
-        <scope>test</scope>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.4.2</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.4.2</version>
-        <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.4.2</version>
+      <scope>test</scope>
     </dependency>
-        </dependencies>
+  </dependencies>
 
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/pom.xml
@@ -1,66 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-#macro( compilerProperties $ver )
-  #if ($ver == "9" || $ver == "10" || $ver == "11" || $ver == "12" || $ver == "13" || $ver == "14")
-    <maven.compiler.release>${ver}</maven.compiler.release>
-  #else
-    <maven.compiler.source>${ver}</maven.compiler.source>
-    <maven.compiler.target>${ver}</maven.compiler.target>
-  #end
-#end
 
-#macro( junit $ver )
-  #if ( $ver.startsWith("4.") )
-    <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-  #elseif ( $ver.startsWith("5.") )
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-  #end
-#end
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>\${groupId}</groupId>
-  <artifactId>\${artifactId}</artifactId>
-  <version>\${version}</version>
+  <groupId>archetype.it</groupId>
+  <artifactId>java-11-junit-542-quickstart</artifactId>
+  <version>0.1-SNAPSHOT</version>
 
-  <name>\${artifactId}</name>
+  <name>java-11-junit-542-quickstart</name>
   <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    #if ( ${javaCompilerVersion} == $null )
-      #compilerProperties( "1.7" )
-    #else
-      #compilerProperties( ${javaCompilerVersion} )
-    #end
-  </properties>
+                <maven.compiler.release>11</maven.compiler.release>
+        </properties>
 
   <dependencies>
-    #if ( ${junitVersion} == $null )
-      #junit( "4.11" )
-    #else
-      #junit( ${junitVersion} )
-    #end
-  </dependencies>
+                <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.4.2</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.4.2</version>
+        <scope>test</scope>
+    </dependency>
+        </dependencies>
 
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
@@ -68,41 +40,41 @@
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>${clean}</version>
+          <version>3.1.0</version>
         </plugin>
         <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>${resources}</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${compiler}</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire}</version>
+          <version>2.22.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>${jar}</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
-          <version>${install}</version>
+          <version>2.5.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>${deploy}</version>
+          <version>2.8.2</version>
         </plugin>
         <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>${site}</version>
+          <version>3.7.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>${pir}</version>
+          <version>3.0.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/pom.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/src/main/java/it/pkg/App.java
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/src/main/java/it/pkg/App.java
@@ -1,4 +1,4 @@
-package $package;
+package it.pkg;
 
 /**
  * Hello world!

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/src/test/java/it/pkg/AppTest.java
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11-junit-5.4.2/reference/src/test/java/it/pkg/AppTest.java
@@ -1,0 +1,20 @@
+package it.pkg;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest {
+
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue() {
+        assertTrue(true);
+    }
+}
+

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11/archetype.properties
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11/archetype.properties
@@ -1,5 +1,5 @@
 groupId=archetype.it
-artifactId=basic-quickstart
+artifactId=java-11-quickstart
 version=0.1-SNAPSHOT
 package=it.pkg
-
+javaCompilerVersion=11

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11/goal.txt
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11/goal.txt
@@ -1,0 +1,1 @@
+validate

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/pom.xml
@@ -1,66 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-#macro( compilerProperties $ver )
-  #if ($ver == "9" || $ver == "10" || $ver == "11" || $ver == "12" || $ver == "13" || $ver == "14")
-    <maven.compiler.release>${ver}</maven.compiler.release>
-  #else
-    <maven.compiler.source>${ver}</maven.compiler.source>
-    <maven.compiler.target>${ver}</maven.compiler.target>
-  #end
-#end
 
-#macro( junit $ver )
-  #if ( $ver.startsWith("4.") )
-    <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-  #elseif ( $ver.startsWith("5.") )
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-  #end
-#end
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>\${groupId}</groupId>
-  <artifactId>\${artifactId}</artifactId>
-  <version>\${version}</version>
+  <groupId>archetype.it</groupId>
+  <artifactId>java-11-quickstart</artifactId>
+  <version>0.1-SNAPSHOT</version>
 
-  <name>\${artifactId}</name>
+  <name>java-11-quickstart</name>
   <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    #if ( ${javaCompilerVersion} == $null )
-      #compilerProperties( "1.7" )
-    #else
-      #compilerProperties( ${javaCompilerVersion} )
-    #end
-  </properties>
+                <maven.compiler.release>11</maven.compiler.release>
+        </properties>
 
   <dependencies>
-    #if ( ${junitVersion} == $null )
-      #junit( "4.11" )
-    #else
-      #junit( ${junitVersion} )
-    #end
-  </dependencies>
+                <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+        <scope>test</scope>
+    </dependency>
+        </dependencies>
 
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
@@ -68,41 +34,41 @@
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>${clean}</version>
+          <version>3.1.0</version>
         </plugin>
         <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>${resources}</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${compiler}</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire}</version>
+          <version>2.22.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>${jar}</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
-          <version>${install}</version>
+          <version>2.5.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>${deploy}</version>
+          <version>2.8.2</version>
         </plugin>
         <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>${site}</version>
+          <version>3.7.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>${pir}</version>
+          <version>3.0.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/pom.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/pom.xml
@@ -16,17 +16,17 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-                <maven.compiler.release>11</maven.compiler.release>
-        </properties>
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
 
   <dependencies>
-                <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.11</version>
-        <scope>test</scope>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
     </dependency>
-        </dependencies>
+  </dependencies>
 
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/src/main/java/it/pkg/App.java
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/src/main/java/it/pkg/App.java
@@ -1,4 +1,4 @@
-package $package;
+package it.pkg;
 
 /**
  * Hello world!

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/src/test/java/it/pkg/AppTest.java
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-11/reference/src/test/java/it/pkg/AppTest.java
@@ -1,0 +1,20 @@
+package it.pkg;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest {
+
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue() {
+        assertTrue(true);
+    }
+}
+

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/archetype.properties
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/archetype.properties
@@ -1,0 +1,6 @@
+groupId=archetype.it
+artifactId=java-8-junit-412-quickstart
+version=0.1-SNAPSHOT
+package=it.pkg
+javaCompilerVersion=1.8
+junitVersion=4.12

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/goal.txt
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/goal.txt
@@ -1,0 +1,1 @@
+validate

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/pom.xml
@@ -16,18 +16,18 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-                <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-        </properties>
+  </properties>
 
   <dependencies>
-                <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.12</version>
-        <scope>test</scope>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
     </dependency>
-        </dependencies>
+  </dependencies>
 
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/pom.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/pom.xml
@@ -1,66 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-#macro( compilerProperties $ver )
-  #if ($ver == "9" || $ver == "10" || $ver == "11" || $ver == "12" || $ver == "13" || $ver == "14")
-    <maven.compiler.release>${ver}</maven.compiler.release>
-  #else
-    <maven.compiler.source>${ver}</maven.compiler.source>
-    <maven.compiler.target>${ver}</maven.compiler.target>
-  #end
-#end
 
-#macro( junit $ver )
-  #if ( $ver.startsWith("4.") )
-    <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-  #elseif ( $ver.startsWith("5.") )
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-  #end
-#end
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>\${groupId}</groupId>
-  <artifactId>\${artifactId}</artifactId>
-  <version>\${version}</version>
+  <groupId>archetype.it</groupId>
+  <artifactId>java-8-junit-412-quickstart</artifactId>
+  <version>0.1-SNAPSHOT</version>
 
-  <name>\${artifactId}</name>
+  <name>java-8-junit-412-quickstart</name>
   <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    #if ( ${javaCompilerVersion} == $null )
-      #compilerProperties( "1.7" )
-    #else
-      #compilerProperties( ${javaCompilerVersion} )
-    #end
-  </properties>
+                <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+        </properties>
 
   <dependencies>
-    #if ( ${junitVersion} == $null )
-      #junit( "4.11" )
-    #else
-      #junit( ${junitVersion} )
-    #end
-  </dependencies>
+                <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+        <scope>test</scope>
+    </dependency>
+        </dependencies>
 
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
@@ -68,41 +35,41 @@
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>${clean}</version>
+          <version>3.1.0</version>
         </plugin>
         <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>${resources}</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${compiler}</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire}</version>
+          <version>2.22.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>${jar}</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
-          <version>${install}</version>
+          <version>2.5.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>${deploy}</version>
+          <version>2.8.2</version>
         </plugin>
         <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>${site}</version>
+          <version>3.7.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>${pir}</version>
+          <version>3.0.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/src/main/java/it/pkg/App.java
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/src/main/java/it/pkg/App.java
@@ -1,4 +1,4 @@
-package $package;
+package it.pkg;
 
 /**
  * Hello world!

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/src/test/java/it/pkg/AppTest.java
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8-junit-4.12/reference/src/test/java/it/pkg/AppTest.java
@@ -1,0 +1,20 @@
+package it.pkg;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest {
+
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue() {
+        assertTrue(true);
+    }
+}
+

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8/archetype.properties
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8/archetype.properties
@@ -1,5 +1,5 @@
 groupId=archetype.it
-artifactId=basic-quickstart
+artifactId=java-8-quickstart
 version=0.1-SNAPSHOT
 package=it.pkg
-
+javaCompilerVersion=1.8

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8/goal.txt
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8/goal.txt
@@ -1,0 +1,1 @@
+validate

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/pom.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/pom.xml
@@ -16,18 +16,18 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-                <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-        </properties>
+  </properties>
 
   <dependencies>
-                <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.11</version>
-        <scope>test</scope>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
     </dependency>
-        </dependencies>
+  </dependencies>
 
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/pom.xml
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/pom.xml
@@ -1,66 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-#macro( compilerProperties $ver )
-  #if ($ver == "9" || $ver == "10" || $ver == "11" || $ver == "12" || $ver == "13" || $ver == "14")
-    <maven.compiler.release>${ver}</maven.compiler.release>
-  #else
-    <maven.compiler.source>${ver}</maven.compiler.source>
-    <maven.compiler.target>${ver}</maven.compiler.target>
-  #end
-#end
 
-#macro( junit $ver )
-  #if ( $ver.startsWith("4.") )
-    <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-  #elseif ( $ver.startsWith("5.") )
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>${ver}</version>
-        <scope>test</scope>
-    </dependency>
-  #end
-#end
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>\${groupId}</groupId>
-  <artifactId>\${artifactId}</artifactId>
-  <version>\${version}</version>
+  <groupId>archetype.it</groupId>
+  <artifactId>java-8-quickstart</artifactId>
+  <version>0.1-SNAPSHOT</version>
 
-  <name>\${artifactId}</name>
+  <name>java-8-quickstart</name>
   <!-- FIXME change it to the project's website -->
   <url>http://www.example.com</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    #if ( ${javaCompilerVersion} == $null )
-      #compilerProperties( "1.7" )
-    #else
-      #compilerProperties( ${javaCompilerVersion} )
-    #end
-  </properties>
+                <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+        </properties>
 
   <dependencies>
-    #if ( ${junitVersion} == $null )
-      #junit( "4.11" )
-    #else
-      #junit( ${junitVersion} )
-    #end
-  </dependencies>
+                <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+        <scope>test</scope>
+    </dependency>
+        </dependencies>
 
   <build>
     <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
@@ -68,41 +35,41 @@
         <!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>${clean}</version>
+          <version>3.1.0</version>
         </plugin>
         <!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>${resources}</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>${compiler}</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>${surefire}</version>
+          <version>2.22.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>${jar}</version>
+          <version>3.0.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-install-plugin</artifactId>
-          <version>${install}</version>
+          <version>2.5.2</version>
         </plugin>
         <plugin>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>${deploy}</version>
+          <version>2.8.2</version>
         </plugin>
         <!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>${site}</version>
+          <version>3.7.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>${pir}</version>
+          <version>3.0.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/src/main/java/it/pkg/App.java
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/src/main/java/it/pkg/App.java
@@ -1,4 +1,4 @@
-package $package;
+package it.pkg;
 
 /**
  * Hello world!

--- a/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/src/test/java/it/pkg/AppTest.java
+++ b/maven-archetype-quickstart/src/test/resources/projects/it-java-8/reference/src/test/java/it/pkg/AppTest.java
@@ -1,0 +1,20 @@
+package it.pkg;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for simple App.
+ */
+public class AppTest {
+
+    /**
+     * Rigorous Test :-)
+     */
+    @Test
+    public void shouldAnswerWithTrue() {
+        assertTrue(true);
+    }
+}
+


### PR DESCRIPTION
## Enabled generating Java 9+ projects as well as using JUnit 5.x

I have kept the plugin backwards compatible -- if `javaCompilerVersion` and `junitVersion` properties are not passed to the plugin it will work as before and generate a Java 1.8 project with JUnit 4.11.

---

#### Update

As JUnit 4.12 is backwards compatible with 4.11, per @eolivelli's suggestion now the default JUnit version is 4.12.