### PR TITLE
[MARCHETYPES-75] Bump web archetype deployment descriptor to v4, portlet to v3

### DIFF
--- a/maven-archetype-portlet/src/main/resources/archetype-resources/src/main/jetspeed/web.xml
+++ b/maven-archetype-portlet/src/main/resources/archetype-resources/src/main/jetspeed/web.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-                         "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app
+    version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd ">
+
   <display-name>${artifactId} Wrapper</display-name>
 
   <description>Generated Portlet Wrapper</description>
 
   <servlet>
-    <servlet-name>${artifactId}</servlet-name>
-    <display-name>${artifactId} Portlet</display-name>
     <description>Portlet for Jetspeed Fusion</description>
+    <display-name>${artifactId} Portlet</display-name>
+    <servlet-name>${artifactId}</servlet-name>
     <servlet-class>org.apache.jetspeed.container.JetspeedContainerServlet</servlet-class>
 
     <init-param>
@@ -29,8 +34,10 @@
     <url-pattern>/container/*</url-pattern>
   </servlet-mapping>
 
-  <taglib>
-    <taglib-uri>http://java.sun.com/portlet</taglib-uri>
-    <taglib-location>/WEB-INF/tld/portlet.tld</taglib-location>
-  </taglib>
+  <jsp-config>
+    <taglib>
+      <taglib-uri>http://java.sun.com/portlet</taglib-uri>
+      <taglib-location>/WEB-INF/tld/portlet.tld</taglib-location>
+    </taglib>
+  </jsp-config>
 </web-app>

--- a/maven-archetype-portlet/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/portlet.xml
+++ b/maven-archetype-portlet/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/portlet.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <portlet-app
-    xmlns="http://java.sun.com/xml/ns/portlet/portlet-app_1_0.xsd"
-    version="1.0"
+    xmlns="http://xmlns.jcp.org/xml/ns/portlet/portlet-app_3_0.xsd"
+    version="3.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/portlet/portlet-app_1_0.xsd
-                        http://java.sun.com/xml/ns/portlet/portlet-app_1_0.xsd">
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/portlet
+                        http://xmlns.jcp.org/xml/ns/portlet/portlet-app_3_0.xsd">
 
   <portlet>
     <description>Write here a short description about your portlet.</description>

--- a/maven-archetype-portlet/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/maven-archetype-portlet/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-                         "http://java.sun.com/dtd/web-app_2_3.dtd">
-<web-app>
+<web-app
+    version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd ">
+
   <display-name>FortunePortlet</display-name>
 
   <description>Automated generated Application Wrapper</description>
 
   <servlet>
-    <servlet-name>${artifactId}</servlet-name>
-    <display-name>${artifactId} Portlet</display-name>
     <description>Generated Portlet Wrapper</description>
+    <display-name>${artifactId} Portlet</display-name>
+    <servlet-name>${artifactId}</servlet-name>
     <servlet-class>org.apache.pluto.core.PortletServlet</servlet-class>
 
     <init-param>
@@ -29,8 +34,10 @@
     <url-pattern>/${artifactId}/*</url-pattern>
   </servlet-mapping>
 
-  <taglib>
-    <taglib-uri>http://java.sun.com/portlet</taglib-uri>
-    <taglib-location>/WEB-INF/tld/portlet.tld</taglib-location>
-  </taglib>
+  <jsp-config>
+    <taglib>
+      <taglib-uri>http://java.sun.com/portlet</taglib-uri>
+      <taglib-location>/WEB-INF/tld/portlet.tld</taglib-location>
+    </taglib>
+  </jsp-config>
 </web-app>

--- a/maven-archetype-webapp/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/maven-archetype-webapp/src/main/resources-filtered/archetype-resources/pom.xml
@@ -15,8 +15,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>

--- a/maven-archetype-webapp/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
+++ b/maven-archetype-webapp/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,10 @@
-<!DOCTYPE web-app PUBLIC
- "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
- "http://java.sun.com/dtd/web-app_2_3.dtd" >
-
-<web-app>
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+    version="4.0"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xml="http://www.w3.org/XML/1998/namespace"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
   <display-name>Archetype Created Web Application</display-name>
 </web-app>

--- a/maven-archetype-webapp/src/main/resources/archetype-resources/src/main/webapp/index.jsp
+++ b/maven-archetype-webapp/src/main/resources/archetype-resources/src/main/webapp/index.jsp
@@ -1,5 +1,5 @@
 <html>
 <body>
-<h2>Hello World!</h2>
+<h2><%= "Hello World!" %></h2>
 </body>
 </html>


### PR DESCRIPTION
Generated webapps will refer to the web-app 4.0 schema, portlets to
the portlet 3.0 schema and corresponding web-app 3.1 schema.