### PR TITLE
[MARCHETYPES-67] Fix maven-archetype-plugin test case

### DIFF
--- a/maven-archetype-plugin/src/main/resources/archetype-resources/src/test/java/MyMojoTest.java
+++ b/maven-archetype-plugin/src/main/resources/archetype-resources/src/test/java/MyMojoTest.java
@@ -62,6 +62,9 @@ public class MyMojoTest
         File touch = new File( outputDirectory, "touch.txt" );
         assertTrue( touch.exists() );
 
+        File expectedOutputDirectory = new File
+          (pom.getAbsoluteFile(), "target/test-harness/project-to-test");
+        assertEquals(expectedOutputDirectory, outputDirectory);
     }
 
     /** Do not need the MojoRule. */

--- a/maven-archetype-plugin/src/main/resources/archetype-resources/src/test/resources/project-to-test/pom.xml
+++ b/maven-archetype-plugin/src/main/resources/archetype-resources/src/test/resources/project-to-test/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>${groupId}</groupId>
-  <artifactId>${artifactId}</artifactId>
+  <artifactId>project-to-test</artifactId>
   <version>${version}</version>
   <packaging>jar</packaging>
   <name>Test MyMojo</name>
@@ -28,7 +28,8 @@
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-my-plugin</artifactId>
+        <groupId>${groupId}</groupId>
+        <artifactId>${artifactId}</artifactId>
         <configuration>
           <!-- Specify the MyMojo parameter -->
           <outputDirectory>target/test-harness/project-to-test</outputDirectory>


### PR DESCRIPTION
As described here https://issues.apache.org/jira/browse/MARCHETYPES-67

The POM test project for unit test was referring to a non existent plugin "maven-my-plugin" instead of referring to the plugin created by the artifact.

The unit test also did not check the correct configuration of the test project. I've added a further assertion in the unit test; I made sure it fails without the patch to the POM test project; with the patched POM test project everything works.

Following this checklist to help us incorporate your
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MARCHETYPES) filed
       for the change (usually before you start working on it).  Trivial changes like typos do not
       require a JIRA issue. Your pull request should address just this issue, without
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MARCHETYPES-XXX] SUMMARY`, where you replace `MARCHETYPES-XXX`
       and `SUMMARY` with the appropriate JIRA issue. Best practice is to use the JIRA issue
       title in the pull request title and in the first line of the commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
