### PR TITLE
Add tests with Java 8 and 21

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -25,3 +25,5 @@ jobs:
   build:
     name: Verify
     uses: apache/maven-gh-actions-shared/.github/workflows/maven-verify.yml@v3
+    with:
+      jdk-matrix: '[ "8", "11", "17", "21" ]'


### PR DESCRIPTION
Originally by @slachiewicz

Based on the "discussions" in:
  https://lists.apache.org/thread/chqcxvlko3nz6cgrs2kzjrdy5tv9spkx  ,  https://github.com/apache/maven-archetypes/pull/22 ,  https://github.com/apache/maven-archetypes/pull/20 ,  https://github.com/apache/maven-archetypes/pull/18 

the base commit ensuring the tests run on all live LTS javas