### PR TITLE
Renamed local variable in maven archetype quickstart

### DIFF
--- a/maven-archetype-quickstart/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/maven-archetype-quickstart/src/main/resources-filtered/archetype-resources/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-#macro( compilerProperties $jcv )
+#macro( compilerProperties $javaCompilerVersionLocal )
 #set( $Double = 0.0 )
-#if ( $Double.valueOf($jcv) > 8 )
-    <maven.compiler.release>${jcv}</maven.compiler.release>
+#if ( $Double.valueOf($javaCompilerVersionLocal) > 8 )
+    <maven.compiler.release>${javaCompilerVersionLocal}</maven.compiler.release>
 #else
-    <maven.compiler.source>${jcv}</maven.compiler.source>
-    <maven.compiler.target>${jcv}</maven.compiler.target>
+    <maven.compiler.source>${javaCompilerVersionLocal}</maven.compiler.source>
+    <maven.compiler.target>${javaCompilerVersionLocal}</maven.compiler.target>
 #end
 #end
 #macro( junit $ver )

--- a/maven-archetype-quickstart/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/maven-archetype-quickstart/src/main/resources-filtered/archetype-resources/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-#macro( compilerProperties $javaCompilerVersion )
+#macro( compilerProperties $jcv )
 #set( $Double = 0.0 )
-#if ( $Double.valueOf($javaCompilerVersion) > 8 )
-    <maven.compiler.release>${javaCompilerVersion}</maven.compiler.release>
+#if ( $Double.valueOf($jcv) > 8 )
+    <maven.compiler.release>${jcv}</maven.compiler.release>
 #else
-    <maven.compiler.source>${javaCompilerVersion}</maven.compiler.source>
-    <maven.compiler.target>${javaCompilerVersion}</maven.compiler.target>
+    <maven.compiler.source>${jcv}</maven.compiler.source>
+    <maven.compiler.target>${jcv}</maven.compiler.target>
 #end
 #end
 #macro( junit $ver )


### PR DESCRIPTION
There is macro which is using parameter and its local occurrence of same name as is global property, thus shadowing it. This PR is renaming it so it is unique or at least distinguishable (second commit) 

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will
       be performed on your pull request automatically.

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
